### PR TITLE
Capitalize token type sent along access token

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ async function getToken(authOptions, tokenCache, forceNewToken) {
 }
 
 function addAuthHeaders(token, options, authOptions) {
+  const tokenType = token.token_type.charAt(0).toUpperCase() + token.token_type.substring(1); 
   let apiKey = authOptions.clientId;
   let xrequestid = uuid().replace(/-/g, '');
 
@@ -55,7 +56,7 @@ function addAuthHeaders(token, options, authOptions) {
 
   return merge(options, {
     headers: {
-      authorization: `${token.token_type} ${token.access_token}`,
+      authorization: `${tokenType} ${token.access_token}`,
       'x-api-key': apiKey,
       'x-request-id': xrequestid,
       'x-gw-ims-org-id': authOptions.orgId

--- a/index.js
+++ b/index.js
@@ -40,8 +40,12 @@ async function getToken(authOptions, tokenCache, forceNewToken) {
   }
 }
 
+function capFirst(s) {
+  return s[0].toUpperCase() + s.slice(1);
+}
+
 function addAuthHeaders(token, options, authOptions) {
-  const tokenType = token.token_type.charAt(0).toUpperCase() + token.token_type.substring(1); 
+  const tokenType = capFirst(token.token_type);
   let apiKey = authOptions.clientId;
   let xrequestid = uuid().replace(/-/g, '');
 

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -27,7 +27,7 @@ jest.mock('node-fetch');
 
 function expectHeaders(url, options, access_token, apikey, orgid) {
   expect(options.headers).toBeDefined();
-  expect(options.headers['authorization']).toBe(`bearer ${access_token}`);
+  expect(options.headers['authorization']).toBe(`Bearer ${access_token}`);
   expect(options.headers['x-api-key']).toBe(apikey);
   expect(options.headers['x-gw-ims-org-id']).toBe(orgid);
   expect(options.headers['x-request-id']).toHaveLength(32);

--- a/test/mockData.js
+++ b/test/mockData.js
@@ -61,7 +61,7 @@ module.exports = {
   },
   valid_token: {
     [TOKEN_KEY]: {
-      token_type: 'Bearer',
+      token_type: 'bearer',
       access_token: 'abcabc',
       expires_in: 86399956,
       expires_at: Date.now() + 100000

--- a/test/mockData.js
+++ b/test/mockData.js
@@ -61,7 +61,7 @@ module.exports = {
   },
   valid_token: {
     [TOKEN_KEY]: {
-      token_type: 'bearer',
+      token_type: 'Bearer',
       access_token: 'abcabc',
       expires_in: 86399956,
       expires_at: Date.now() + 100000

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -74,7 +74,7 @@ describe('Validate custom storage', () => {
     fetch.mockImplementation((url, options) => {
       expect(options.headers).toBeDefined();
       expect(options.headers['authorization']).toBe(
-        `${token.token_type} ${token.access_token}`
+        `Bearer ${token.access_token}`
       );
       return Promise.resolve(mockData.responseOK);
     });
@@ -102,7 +102,7 @@ describe('Validate custom storage', () => {
     fetch.mockImplementation((url, options) => {
       expect(options.headers).toBeDefined();
       expect(options.headers['authorization']).toBe(
-        `${token.token_type} ${token.access_token}`
+        `Bearer ${token.access_token}`
       );
       return Promise.resolve(mockData.responseOK);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes issue https://github.com/adobe/adobe-fetch/issues/23

`adobe-fetch` sends the token type as "bearer" (lowercase) as it's received from `@adobe/jwt-auth`, however it seems at at least the Adobe Privacy Services APIs expect the token to be spelled as "Bearer" which seems to be correctly following [rfc6750](https://tools.ietf.org/html/rfc6750#section-2.1)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Fix bug preventing calls to Privacy Service APIs

## How Has This Been Tested?

Tested existing application with updated code. This fix was not tested against other endpoints.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed